### PR TITLE
gRPC on Endpoints Quickstart sample.

### DIFF
--- a/endpoints/getting-started-grpc/.gitignore
+++ b/endpoints/getting-started-grpc/.gitignore
@@ -1,0 +1,8 @@
+greeter_client
+greeter_server
+greeter_server_static
+helloworld.grpc.pb.cc
+helloworld.grpc.pb.h
+helloworld.pb.cc
+helloworld.pb.h
+out.pb

--- a/endpoints/getting-started-grpc/Dockerfile
+++ b/endpoints/getting-started-grpc/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+
+COPY greeter_server_static /
+
+CMD ["/greeter_server_static"]

--- a/endpoints/getting-started-grpc/Dockerfile-builder
+++ b/endpoints/getting-started-grpc/Dockerfile-builder
@@ -1,0 +1,24 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google-samples/grpc-cxx:1.1.0
+
+RUN dnf -y install glibc-static libstdc++-static
+
+COPY . /code
+WORKDIR /code
+
+RUN PKG_CONFIG_PATH=/usr/local/lib/pkgconfig make greeter_server_static
+
+CMD ["cat", "greeter_server_static"]

--- a/endpoints/getting-started-grpc/Makefile
+++ b/endpoints/getting-started-grpc/Makefile
@@ -1,0 +1,127 @@
+#
+# Copyright 2015, Google Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+HOST_SYSTEM = $(shell uname | cut -f 1 -d_)
+SYSTEM ?= $(HOST_SYSTEM)
+CXX = g++
+CPPFLAGS += -I/usr/local/include -pthread
+CXXFLAGS += -std=c++11
+ifeq ($(SYSTEM),Darwin)
+LDFLAGS += -L/usr/local/lib `pkg-config --libs grpc++ grpc`       \
+           -lgrpc++_reflection \
+           -lprotobuf -lpthread -ldl
+else
+LDFLAGS += -L/usr/local/lib `pkg-config --libs grpc++ grpc`       \
+           -Wl,--no-as-needed -lgrpc++_reflection -Wl,--as-needed \
+           -lprotobuf -lpthread -ldl
+endif
+PROTOC = protoc
+GRPC_CPP_PLUGIN = grpc_cpp_plugin
+GRPC_CPP_PLUGIN_PATH ?= `which $(GRPC_CPP_PLUGIN)`
+
+PROTOS_PATH = protos
+
+vpath %.proto $(PROTOS_PATH)
+
+all: system-check greeter_client greeter_server
+
+greeter_client: helloworld.pb.o helloworld.grpc.pb.o greeter_client.o
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+greeter_server: helloworld.pb.o helloworld.grpc.pb.o greeter_server.o
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+greeter_server_static: helloworld.pb.o helloworld.grpc.pb.o greeter_server.o
+	$(CXX) $^ $(LDFLAGS) -static -o $@
+
+.PRECIOUS: %.grpc.pb.cc
+%.grpc.pb.cc: %.proto
+	$(PROTOC) -I $(PROTOS_PATH) --grpc_out=. --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN_PATH) $<
+
+.PRECIOUS: %.pb.cc
+%.pb.cc: %.proto
+	$(PROTOC) -I $(PROTOS_PATH) --cpp_out=. $<
+
+clean:
+	rm -f *.o *.pb.cc *.pb.h greeter_client greeter_server greeter_server_static
+
+
+# The following is to test your system and ensure a smoother experience.
+# They are by no means necessary to actually compile a grpc-enabled software.
+
+PROTOC_CMD = which $(PROTOC)
+PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.3
+PLUGIN_CHECK_CMD = which $(GRPC_CPP_PLUGIN)
+HAS_PROTOC = $(shell $(PROTOC_CMD) > /dev/null && echo true || echo false)
+ifeq ($(HAS_PROTOC),true)
+HAS_VALID_PROTOC = $(shell $(PROTOC_CHECK_CMD) 2> /dev/null && echo true || echo false)
+endif
+HAS_PLUGIN = $(shell $(PLUGIN_CHECK_CMD) > /dev/null && echo true || echo false)
+
+SYSTEM_OK = false
+ifeq ($(HAS_VALID_PROTOC),true)
+ifeq ($(HAS_PLUGIN),true)
+SYSTEM_OK = true
+endif
+endif
+
+system-check:
+ifneq ($(HAS_VALID_PROTOC),true)
+	@echo " DEPENDENCY ERROR"
+	@echo
+	@echo "You don't have protoc 3.0.0 installed in your path."
+	@echo "Please install Google protocol buffers 3.0.0 and its compiler."
+	@echo "You can find it here:"
+	@echo
+	@echo "   https://github.com/google/protobuf/releases/tag/v3.0.0"
+	@echo
+	@echo "Here is what I get when trying to evaluate your version of protoc:"
+	@echo
+	-$(PROTOC) --version
+	@echo
+	@echo
+endif
+ifneq ($(HAS_PLUGIN),true)
+	@echo " DEPENDENCY ERROR"
+	@echo
+	@echo "You don't have the grpc c++ protobuf plugin installed in your path."
+	@echo "Please install grpc. You can find it here:"
+	@echo
+	@echo "   https://github.com/grpc/grpc"
+	@echo
+	@echo "Here is what I get when trying to detect if you have the plugin:"
+	@echo
+	-which $(GRPC_CPP_PLUGIN)
+	@echo
+	@echo
+endif
+ifneq ($(SYSTEM_OK),true)
+	@false
+endif

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -1,0 +1,169 @@
+# Endpoints Getting Started with gRPC & C++ Quickstart
+
+It is assumed that you have a working C++ environment,
+[ProtoBuf](https://github.com/google/protobuf/blob/master/src/README.md) and
+[gRPC](http://www.grpc.io/docs/quickstart/cpp.html) installed, and a
+Google Cloud account and [SDK](https://cloud.google.com/sdk/)
+configured.
+
+You either need Docker installed or the ability to compile Linux
+64-bit static C++ binaries.
+
+1. Build the local client and server.
+
+    ```bash
+    make
+    ```
+
+1. Test running the code, optional:
+
+    ```bash
+    # In the background or another terminal run the server:
+    ./greeter_server
+
+    # Check the client parameters:
+    ./greeter_client
+
+    # Run the client
+    ./greeter_client localhost:50051 test
+    ```
+
+1. Generate the `out.pb` from the proto file.
+
+    ```bash
+    protoc --include_imports --include_source_info protos/helloworld.proto --descriptor_set_out out.pb
+    ```
+
+1. Edit, `api_config.yaml`. Replace `MY_PROJECT_ID` with your project id.
+
+1. Deploy your service config to Service Management:
+
+    ```bash
+    gcloud service-management deploy out.pb api_config.yaml
+    # The Config ID should be printed out, looks like: 2017-02-01r0, remember this
+
+    # set your project to make commands easier
+    GCLOUD_PROJECT=<Your Project ID>
+
+    # Print out your Config ID again, in case you missed it
+    gcloud service-management configs list --service hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
+    ```
+
+1. Also get an API key from the Console's API Manager for use in the
+   client later. (https://console.cloud.google.com/apis/credentials)
+
+1. Build the static server binary. Either
+
+  1. Use the Docker build:
+
+      ```bash
+      make clean
+      docker build -t static-server-builder -f Dockerfile-builder .
+      docker run --rm static-server-builder > greeter_server_static
+      chmod +x greeter_server_static
+      ```
+
+  1. If you can build a static Linux x64 binary, just run:
+
+      ```bash
+      make greeter_server_static
+      ```
+
+1. Build a docker image for your gRPC server, store in your Registry
+
+    ```bash
+    gcloud container builds submit --tag gcr.io/${GCLOUD_PROJECT}/cpp-grpc-hello:1.0 .
+    ```
+
+1. Either deploy to GCE (below) or GKE (further down)
+
+### GCE
+
+1. Create your instance and ssh in.
+
+    ```bash
+    gcloud compute instances create grpc-host --image-family gci-stable --image-project google-containers --tags=http-server
+    gcloud compute ssh grpc-host
+    ```
+
+1. Set some variables to make commands easier
+
+    ```bash
+    GCLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
+    SERVICE_NAME=hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
+    SERVICE_CONFIG_ID=<Your Config ID>
+    ```
+
+1. Pull your credentials to access Container Registry, and run your
+   gRPC server container
+
+    ```bash
+    /usr/share/google/dockercfg_update.sh
+    docker run -d --name=grpc-hello gcr.io/${GCLOUD_PROJECT}/cpp-grpc-hello:1.0
+    ```
+
+1. Run the Endpoints proxy
+
+    ```bash
+    docker run --detach --name=esp \
+        -p 80:9000 \
+        --link=grpc-hello:grpc-hello \
+        gcr.io/endpoints-release/endpoints-runtime:1 \
+        -s ${SERVICE_NAME} \
+        -v ${SERVICE_CONFIG_ID} \
+        -P 9000 \
+        -a grpc://grpc-hello:50051
+    ```
+
+1. Back on your local machine, get the external IP of your GCE instance.
+
+    ```bash
+    gcloud compute instances list
+    ```
+
+1. Run the client
+
+    ```bash
+    ./greeter_client <IP of GCE Instance>:80 <API Key from Console>
+    ```
+
+1. Cleanup
+
+    ```bash
+    gcloud compute instances delete grpc-host
+    ```
+
+### GKE
+
+1. Create a cluster
+
+    ```bash
+    gcloud container clusters create my-cluster
+    ```
+
+1. Edit `container-engine.yaml`. Replace `SERVICE_NAME`,
+   `SERVICE_CONFIG_ID`, and `GCLOUD_PROJECT` with your values.
+
+1. Deploy to GKE
+
+    ```bash
+    kubectl create -f ./container-engine.yaml
+    ```
+
+1. Get IP of load balancer, run until you see an External IP.
+
+    ```bash
+    kubectl get svc grpc-hello
+    ```
+
+1. Run the client
+
+    ```bash
+    ./greeter_client <IP of GKE LoadBalancer>:80 <API Key from Console>
+    ```
+
+1. Cleanup
+
+    ```bash
+    gcloud container clusters delete my-cluster
+    ```

--- a/endpoints/getting-started-grpc/api_config.yaml
+++ b/endpoints/getting-started-grpc/api_config.yaml
@@ -1,0 +1,36 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# An example API configuration.
+#
+# Below, replace MY_PROJECT_ID with your Google Cloud Project ID.
+#
+
+# The configuration schema is defined by service.proto file
+# https://github.com/googleapis/googleapis/blob/master/google/api/service.proto
+type: google.api.Service
+config_version: 3
+
+#
+# Name of the service configuration.
+#
+name: hellogrpc.endpoints.MY_PROJECT_ID.cloud.goog
+
+#
+# API title to appear in the user interface (Google Cloud Console).
+#
+title: Hello gRPC API
+apis:
+- name: helloworld.Greeter

--- a/endpoints/getting-started-grpc/container-engine.yaml
+++ b/endpoints/getting-started-grpc/container-engine.yaml
@@ -1,0 +1,54 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-hello
+spec:
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  selector:
+    app: grpc-hello
+  type: LoadBalancer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: grpc-hello
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grpc-hello
+    spec:
+      containers:
+      - name: esp
+        image: gcr.io/endpoints-release/endpoints-runtime:1
+        args: [
+          "-P", "9000",
+          "-a", "grpc://127.0.0.1:50051",
+          "-s", "SERVICE_NAME",
+          "-v", "SERVICE_CONFIG_ID",
+        ]
+        ports:
+          - containerPort: 9000
+      - name: cpp-grpc-hello
+        image: gcr.io/GCLOUD_PROJECT/cpp-grpc-hello:1.0
+        ports:
+          - containerPort: 50051

--- a/endpoints/getting-started-grpc/greeter_client.cc
+++ b/endpoints/getting-started-grpc/greeter_client.cc
@@ -1,0 +1,122 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpc++/grpc++.h>
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/helloworld.grpc.pb.h"
+#else
+#include "helloworld.grpc.pb.h"
+#endif
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using helloworld::HelloRequest;
+using helloworld::HelloReply;
+using helloworld::Greeter;
+
+class GreeterClient {
+ public:
+  GreeterClient(std::shared_ptr<Channel> channel, const std::string& api_key)
+    : stub_(Greeter::NewStub(channel)),
+      api_key_(api_key) {}
+
+  // Assembles the client's payload, sends it and presents the response back
+  // from the server.
+  std::string SayHello(const std::string& user) {
+    // Data we are sending to the server.
+    HelloRequest request;
+    request.set_name(user);
+
+    // Container for the data we expect from the server.
+    HelloReply reply;
+
+    // Context for the client. It could be used to convey extra information to
+    // the server and/or tweak certain RPC behaviors.
+    ClientContext context;
+
+    // Add API Key. This is ignored if not going through the Endpoints
+    // Extensible Service Proxy (ESP)
+    context.AddMetadata("x-api-key", api_key_);
+
+    // The actual RPC.
+    Status status = stub_->SayHello(&context, request, &reply);
+
+    // Act upon its status.
+    if (status.ok()) {
+      return reply.message();
+    } else {
+      std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+      return "RPC failed";
+    }
+  }
+
+ private:
+  std::unique_ptr<Greeter::Stub> stub_;
+  std::string api_key_;
+};
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    std::cout <<
+      "Usage: " << argv[0] << " <host> <api_key> [greetee]" << std::endl <<
+      "" << std::endl <<
+      "Arguments:" << std::endl <<
+      "  host                 gRPC host to connect to, ex: localhost:50051" << std::endl <<
+      "  api_key              API key to add to request" << std::endl <<
+      "  greetee              Optional, Who to greet" << std::endl;
+    return 1;
+  }
+  std::string host = argv[1];
+  std::string api_key = argv[2];
+  std::string greetee = "world";
+  if (argc >= 4) {
+    greetee = argv[3];
+  }
+
+  // Instantiate the client. It requires a channel, out of which the actual RPCs
+  // are created. This channel models a connection to an endpoint (in this case,
+  // localhost at port 50051). We indicate that the channel isn't authenticated
+  // (use of InsecureChannelCredentials()).
+  GreeterClient greeter(
+      grpc::CreateChannel(host, grpc::InsecureChannelCredentials()), api_key);
+  std::string reply = greeter.SayHello(greetee);
+  std::cout << "Greeter received: " << reply << std::endl;
+
+  return 0;
+}

--- a/endpoints/getting-started-grpc/greeter_server.cc
+++ b/endpoints/getting-started-grpc/greeter_server.cc
@@ -1,0 +1,86 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpc++/grpc++.h>
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/helloworld.grpc.pb.h"
+#else
+#include "helloworld.grpc.pb.h"
+#endif
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using helloworld::HelloRequest;
+using helloworld::HelloReply;
+using helloworld::Greeter;
+
+// Logic and data behind the server's behavior.
+class GreeterServiceImpl final : public Greeter::Service {
+  Status SayHello(ServerContext* context, const HelloRequest* request,
+                  HelloReply* reply) override {
+    std::string prefix("Hello ");
+    reply->set_message(prefix + request->name());
+    return Status::OK;
+  }
+};
+
+void RunServer() {
+  std::string server_address("0.0.0.0:50051");
+  GreeterServiceImpl service;
+
+  ServerBuilder builder;
+  // Listen on the given address without any authentication mechanism.
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  // Register "service" as the instance through which we'll communicate with
+  // clients. In this case it corresponds to an *synchronous* service.
+  builder.RegisterService(&service);
+  // Finally assemble the server.
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  // Wait for the server to shutdown. Note that some other thread must be
+  // responsible for shutting down the server for this call to ever return.
+  server->Wait();
+}
+
+int main(int argc, char** argv) {
+  RunServer();
+
+  return 0;
+}

--- a/endpoints/getting-started-grpc/grpc-env/Dockerfile
+++ b/endpoints/getting-started-grpc/grpc-env/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for gcr.io/google-samples/grpc-cxx
+# Official image is here https://hub.docker.com/r/grpc/cxx/
+# This image is based on Fedora to allow easy building of static binaries
+FROM fedora:25
+
+ENV GRPC_RELEASE_TAG v1.1.0
+
+RUN dnf -y install which make gcc gcc-c++ autoconf automake libtool git && \
+    git clone -b ${GRPC_RELEASE_TAG} https://github.com/grpc/grpc /var/local/git/grpc && \
+    cd /var/local/git/grpc && \
+    git submodule update --init && \
+    make && make install && make clean && \
+    cd /var/local/git/grpc/third_party/protobuf && \
+    make && make install && make clean

--- a/endpoints/getting-started-grpc/protos/helloworld.proto
+++ b/endpoints/getting-started-grpc/protos/helloworld.proto
@@ -1,0 +1,47 @@
+// Copyright 2015, Google Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
Code is mostly from: https://github.com/grpc/grpc/tree/master/examples/cpp/helloworld Client is modified to take an api_key and insert it into the request. Endpoints configs and README added. Will eventually replace https://cloud.google.com/endpoints/docs/quickstart-grpc-container-engine and https://cloud.google.com/endpoints/docs/quickstart-grpc-compute-engine-docker bookstore sample with a tabbed helloworld for each language.