### PR TITLE
Set binary file open mode in streaming_transcribe.cc

### DIFF
--- a/speech/api/streaming_transcribe.cc
+++ b/speech/api/streaming_transcribe.cc
@@ -40,7 +40,7 @@ static void MicrophoneThreadMain(
                                       StreamingRecognizeResponse>* streamer,
     char* file_path) {
   StreamingRecognizeRequest request;
-  std::ifstream file_stream(file_path);
+  std::ifstream file_stream(file_path, std::ios::binary);
   const size_t chunk_size = 64 * 1024;
   std::vector<char> chunk(chunk_size);
   while (true) {


### PR DESCRIPTION
On Windows, the first chunk was just a few hundred bytes before the change, maybe because an EOF was in the flac sample file. This was causing an "Audio data streaming too slow" issue.
Adding the flag on ifstream constructor call fixed the issue