### PR TITLE
Initial bigtable/api example with automated builds. (#2)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bigtable/api/googleapis"]
+	path = bigtable/api/googleapis
+	url = https://github.com/googleapis/googleapis.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,55 +21,28 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=16.04 CXX_COMPILER=/usr/bin/clang++
+      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=17.04
     - os: linux
       compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=17.04 CXX_COMPILER=/usr/bin/clang++
+      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=24
     - os: linux
-      compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=24 CXX_COMPILER=/usr/bin/clang++
+      compiler: gcc
+      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=16.04
     - os: linux
+      compiler: gcc
+      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=25
+    - os: osx
       compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=25 CXX_COMPILER=/usr/bin/clang++
-    - os: linux
-      compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=16.04 CXX_COMPILER=/usr/bin/g++
-    - os: linux
-      compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=17.04 CXX_COMPILER=/usr/bin/g++
-    - os: linux
-      compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=24 CXX_COMPILER=/usr/bin/g++
-    - os: linux
-      compiler: clang
-      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=25 CXX_COMPILER=/usr/bin/g++
+      env: MACOSX_BUILD=yes
 
 script:
-  - if [ "${DOCKER_BUILD?}" = "yes" ]; then
-      IMAGE="cached-${DISTRO?}-${DISTRO_VERSION?}";
-      latest_id=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest)
-      cacheargs="";
-      if [ "x${latest_id}" != "x" ]; then
-        cacheargs="--cache-from ${IMAGE?}:latest";
-      fi;
-      echo cache args = $cacheargs;
-      echo IMAGE = $IMAGE;
-      echo IMAGE LATEST ID = $latest_id;
-      sudo docker build -t ${IMAGE?}:tip ${cacheargs?}
-          --build-arg DISTRO_VERSION=${DISTRO_VERSION?}
-          --build-arg CXX_COMPILER=${CXX_COMPILER?}
-          --build-arg TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER}
-          -f bigtable/api/docker/Dockerfile.${DISTRO?} bigtable/;
-    fi
+  - bigtable/api/ci/build-linux.sh
+  - bigtable/api/ci/build-macosx.sh
 
 # Cache the (saved) docker images.
 # With recent version of docker one can reuse a prior image as a
 # source cache, that can speed up the builds, as the dependencies and
 # images can be reused ...
-# TODO() - we need to add a cron job to rebuild without a cache every
-# so often, the dependencies do change and we want to validate that
-# the examples build with the newer versions.  That is easy to do with
-# a cron-based build in Travis that cleans up the cache every X days.
 cache:
   directories:
     - docker-images/ubuntu/16.04
@@ -81,25 +54,11 @@ install:
   # Restore the docker image from the cached directory.  That way we
   # can reuse the steps in the docker image that install
   # pre-requisites and build dependencies ...
-  - sudo apt-get update
-  - sudo apt-get install -y docker-ce
-  - sudo docker --version
-  - TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz;
-    if [ "${DOCKER_BUILD?}" = "yes" -a -f ${TARBALL?} ]; then
-      gunzip <${TARBALL?} | sudo docker load ||
-        echo "Could not load saved image, continue without cache";
-    fi
-  # Some debugging ...
-  - ls -l docker-images/${DISTRO}/${DISTRO_VERSION} || /bin/true
-  - sudo docker image ls
+  - bigtable/api/ci/install-linux.sh
+  - bigtable/api/ci/install-macosx.sh
 
 before_cache:
-  - IMAGE=cached-${DISTRO?}-${DISTRO_VERSION?};
-    TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz;
-    if [ "${DOCKER_BUILD?}" = "yes" ]; then
-      sudo docker image tag ${IMAGE?}:tip ${IMAGE?}:latest ;
-      sudo docker save ${IMAGE?}:latest | gzip - > ${TARBALL?};
-    fi
+  - bigtable/api/ci/cache-linux.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,105 @@
+# Copyright 2017, Google Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+language: cpp
+
+dist: trusty
+sudo: required
+
+matrix:
+  include:
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=16.04 CXX_COMPILER=/usr/bin/clang++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=17.04 CXX_COMPILER=/usr/bin/clang++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=24 CXX_COMPILER=/usr/bin/clang++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=25 CXX_COMPILER=/usr/bin/clang++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=16.04 CXX_COMPILER=/usr/bin/g++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=ubuntu DISTRO_VERSION=17.04 CXX_COMPILER=/usr/bin/g++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=24 CXX_COMPILER=/usr/bin/g++
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=yes DISTRO=fedora DISTRO_VERSION=25 CXX_COMPILER=/usr/bin/g++
+
+script:
+  - if [ "${DOCKER_BUILD?}" = "yes" ]; then
+      IMAGE="cached-${DISTRO?}-${DISTRO_VERSION?}";
+      latest_id=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest)
+      cacheargs="";
+      if [ "x${latest_id}" != "x" ]; then
+        cacheargs="--cache-from ${IMAGE?}:latest";
+      fi;
+      echo cache args = $cacheargs;
+      echo IMAGE = $IMAGE;
+      echo IMAGE LATEST ID = $latest_id;
+      sudo docker build -t ${IMAGE?}:tip ${cacheargs?}
+          --build-arg DISTRO_VERSION=${DISTRO_VERSION?}
+          --build-arg CXX_COMPILER=${CXX_COMPILER?}
+          --build-arg TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER}
+          -f bigtable/api/docker/Dockerfile.${DISTRO?} bigtable/;
+    fi
+
+# Cache the (saved) docker images.
+# With recent version of docker one can reuse a prior image as a
+# source cache, that can speed up the builds, as the dependencies and
+# images can be reused ...
+# TODO() - we need to add a cron job to rebuild without a cache every
+# so often, the dependencies do change and we want to validate that
+# the examples build with the newer versions.  That is easy to do with
+# a cron-based build in Travis that cleans up the cache every X days.
+cache:
+  directories:
+    - docker-images/ubuntu/16.04
+    - docker-images/ubuntu/17.04
+    - docker-images/fedora/24
+    - docker-images/fedora/25
+
+install:
+  # Restore the docker image from the cached directory.  That way we
+  # can reuse the steps in the docker image that install
+  # pre-requisites and build dependencies ...
+  - sudo apt-get update
+  - sudo apt-get install -y docker-ce
+  - sudo docker --version
+  - TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz;
+    if [ "${DOCKER_BUILD?}" = "yes" -a -f ${TARBALL?} ]; then
+      gunzip <${TARBALL?} | sudo docker load ||
+        echo "Could not load saved image, continue without cache";
+    fi
+  # Some debugging ...
+  - ls -l docker-images/${DISTRO}/${DISTRO_VERSION} || /bin/true
+  - sudo docker image ls
+
+before_cache:
+  - IMAGE=cached-${DISTRO?}-${DISTRO_VERSION?};
+    TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz;
+    if [ "${DOCKER_BUILD?}" = "yes" ]; then
+      sudo docker image tag ${IMAGE?}:tip ${IMAGE?}:latest ;
+      sudo docker save ${IMAGE?}:latest | gzip - > ${TARBALL?};
+    fi
+
+notifications:
+  email: false

--- a/bigtable/api/.clang-format
+++ b/bigtable/api/.clang-format
@@ -1,0 +1,3 @@
+---
+# We'll use defaults from the Google Style Guide.
+BasedOnStyle: Google

--- a/bigtable/api/.clang-format
+++ b/bigtable/api/.clang-format
@@ -1,3 +1,11 @@
 ---
 # We'll use defaults from the Google Style Guide.
 BasedOnStyle: Google
+
+IncludeCategories:
+  - Regex: '^<google/'
+    Priority: 1000
+  - Regex: '^<grpc\+\+/'
+    Priority: 2000
+  - Regex: '^<grpc/'
+    Priority: 3000

--- a/bigtable/api/.gitignore
+++ b/bigtable/api/.gitignore
@@ -1,0 +1,7 @@
+googleapis-gens
+Makefile
+cmake_install.cmake
+CMakeFiles/
+CMakeCache.txt
+libgoogleapis.a
+list_instances

--- a/bigtable/api/.gitignore
+++ b/bigtable/api/.gitignore
@@ -5,3 +5,4 @@ CMakeFiles/
 CMakeCache.txt
 libgoogleapis.a
 list_instances
+build/

--- a/bigtable/api/CMakeLists.txt
+++ b/bigtable/api/CMakeLists.txt
@@ -1,0 +1,80 @@
+# Copyright 2017, Google Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+cmake_minimum_required(VERSION 3.5)
+
+# ... define the project name, version, and main programming language ...
+set(PACKAGE_NAME      "cpp-docs-samples-bigtable-api")
+set(PACKAGE_VERSION   "0.1")
+set(PACKAGE_STRING    "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+set(PACKAGE_TARNAME   "${PACKAGE_NAME}-${PACKAGE_VERSION}")
+set(PACKAGE_BUGREPORT "https://github.com/GoogleCloudPlatform/cpp-docs-samples/issues")
+project(${PACKAGE_NAME} CXX C)
+
+# ... configure the Compiler options, we will be using C++11 features,
+# so enable that, both for newer cmake versions ...
+set(CXX_STANDARD_REQUIRED 11)
+# ... and for older ones ...
+set(CMAKE_CXX_STANDARD ${CXX_STANDARD_REQUIRED})
+
+# ... the author is paranoid.  Turn on all available warnings
+# and turn warnings into errors to stop the build if any warning is
+# emitted ...
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-Werror COMPILER_SUPPORTS_WERROR)
+if(COMPILER_SUPPORTS_WERROR)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
+CHECK_CXX_COMPILER_FLAG(-Wall COMPILER_SUPPORTS_WALL)
+if(COMPILER_SUPPORTS_WALL)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif()
+CHECK_CXX_COMPILER_FLAG(/WX COMPILER_SUPPORTS_WX)
+if(COMPILER_SUPPORTS_WX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+endif()
+CHECK_CXX_COMPILER_FLAG(/W4 COMPILER_SUPPORTS_SWALL)
+if(COMPILER_SUPPORTS_SWALL)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Wall")
+endif()
+
+# ... include the functions to compile proto files ...
+include(FindProtobuf)
+
+# ... find the grpc and grpc++ libraries using pkg-config ...
+include(FindPkgConfig)
+pkg_check_modules(GRPCPP REQUIRED grpc++)
+pkg_check_modules(GRPC REQUIRED grpc)
+pkg_check_modules(PROTOBUF REQUIRED protobuf)
+
+# ... define where the googleapis protos can be found, and add that
+# directory to the search path for header files ...
+# Typically you can generate these using:
+#  $ make -C googleapis OUTPUT=$PWD/googleapis-gens
+set(GOOGLEAPIS_PATH "${CMAKE_SOURCE_DIR}/googleapis")
+set(GOOGLEAPIS_GENS_PATH "${GOOGLEAPIS_PATH}-gens")
+include_directories("${GOOGLEAPIS_GENS_PATH}")
+
+################################################################
+# Create targets here ...
+
+# ... discover all the generated Google API files and turn them into a
+# static library ...
+file(GLOB_RECURSE GOOGLEAPIS_SRCS ${GOOGLEAPIS_GENS_PATH}/*.pb.cc)
+file(GLOB_RECURSE GOOGLEAPIS_HDRS ${GOOGLEAPIS_GENS_PATH}/*.pb.h)
+add_library(googleapis ${GOOGLEAPIS_SRCS} ${GOOGLEAPIS_HDRS})
+
+# A very simple example, list the instances for a give project
+add_executable(list_instances list_instances.cc)
+target_link_libraries(list_instances googleapis grpc++ grpc protobuf)

--- a/bigtable/api/CMakeLists.txt
+++ b/bigtable/api/CMakeLists.txt
@@ -54,9 +54,9 @@ include(FindProtobuf)
 
 # ... find the grpc and grpc++ libraries using pkg-config ...
 include(FindPkgConfig)
-pkg_check_modules(GRPCPP REQUIRED grpc++)
-pkg_check_modules(GRPC REQUIRED grpc)
-pkg_check_modules(PROTOBUF REQUIRED protobuf)
+pkg_check_modules(GRPCPP REQUIRED grpc++>=1.4.2)
+pkg_check_modules(GRPC REQUIRED grpc>=4.0)
+pkg_check_modules(PROTOBUF REQUIRED protobuf>=3.0)
 
 # ... define where the googleapis protos can be found, and add that
 # directory to the search path for header files ...

--- a/bigtable/api/CMakeLists.txt
+++ b/bigtable/api/CMakeLists.txt
@@ -22,11 +22,10 @@ set(PACKAGE_TARNAME   "${PACKAGE_NAME}-${PACKAGE_VERSION}")
 set(PACKAGE_BUGREPORT "https://github.com/GoogleCloudPlatform/cpp-docs-samples/issues")
 project(${PACKAGE_NAME} CXX C)
 
-# ... configure the Compiler options, we will be using C++11 features,
-# so enable that, both for newer cmake versions ...
-set(CXX_STANDARD_REQUIRED 11)
-# ... and for older ones ...
-set(CMAKE_CXX_STANDARD ${CXX_STANDARD_REQUIRED})
+# ... configure the Compiler options, we will be using C++14 features,
+# so enable that ...
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ... the author is paranoid.  Turn on all available warnings
 # and turn warnings into errors to stop the build if any warning is
@@ -54,9 +53,11 @@ include(FindProtobuf)
 
 # ... find the grpc and grpc++ libraries using pkg-config ...
 include(FindPkgConfig)
-pkg_check_modules(GRPCPP REQUIRED grpc++>=1.4.2)
+pkg_check_modules(GRPCPP REQUIRED grpc++>=1.4.1)
 pkg_check_modules(GRPC REQUIRED grpc>=4.0)
 pkg_check_modules(PROTOBUF REQUIRED protobuf>=3.0)
+link_directories(${GRPCPP_LIBRARY_DIRS} ${GRPC_LIBRARY_DIRS} ${PROTOBUF_LIBRARY_DIRS})
+include_directories(${GRPCPP_INCLUDE_DIRS} ${GRPC_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS})
 
 # ... define where the googleapis protos can be found, and add that
 # directory to the search path for header files ...
@@ -75,6 +76,11 @@ file(GLOB_RECURSE GOOGLEAPIS_SRCS ${GOOGLEAPIS_GENS_PATH}/*.pb.cc)
 file(GLOB_RECURSE GOOGLEAPIS_HDRS ${GOOGLEAPIS_GENS_PATH}/*.pb.h)
 add_library(googleapis ${GOOGLEAPIS_SRCS} ${GOOGLEAPIS_HDRS})
 
-# A very simple example, list the instances for a give project
 add_executable(list_instances list_instances.cc)
-target_link_libraries(list_instances googleapis grpc++ grpc protobuf)
+target_link_libraries(list_instances googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+add_executable(create_instance create_instance.cc)
+target_link_libraries(create_instance googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+add_executable(delete_instance delete_instance.cc)
+target_link_libraries(delete_instance googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})

--- a/bigtable/api/README.md
+++ b/bigtable/api/README.md
@@ -45,3 +45,27 @@ These samples demonstrate how to call the [Google Cloud Bigtable API](https://cl
 1.  **Install gRPC.**
     1.  Visit [the gRPC github repo](https://github.com/grpc/grpc) and follow the instructions to install gRPC.
     1.  Then, follow the instructions in the **Pre-requisites** section to install **protoc**.
+
+1.  **Download or close this repo** with
+    ```console
+    git clone https://github.com/GoogleCloudPlatform/cpp-docs-samples
+    cd cpp-docs-samples
+    git submodule update --init
+    ```
+
+1.  **Generate googleapis gRPC source code.**
+    ```console
+    cd bigtable/api
+    env -u LANGUAGE make -C googleapis OUTPUT=$PWD/googleapis-gens
+    ```
+
+1.  **Compile the examples**
+    ```console
+    cmake .
+    make -j 2
+    ```
+
+1.  **Run the examples**
+    ```console
+    ./list_instances <project_id>
+    ```

--- a/bigtable/api/README.md
+++ b/bigtable/api/README.md
@@ -1,0 +1,47 @@
+# Bigtable Samples.
+
+These samples demonstrate how to call the [Google Cloud Bigtable API](https://cloud.google.com/bigtable/) using C++.
+
+## Build and Run
+
+1.  **Create a project in the Google Cloud Console**.
+    If you haven't already created a project, create one now. Projects enable
+    you to manage all Google Cloud Platform resources for your app, including
+    deployment, access control, billing, and services.
+    1.  Open the [Google Cloud Console](https://console.cloud.google.com/).
+    1.  In the drop-down menu at the top, select Create a project.
+    1.  Click Show advanced options. Under App Engine location, select a
+        United States location.
+    1.  Give your project a name.
+    1.  Make a note of the project ID, which might be different from the project
+        name. The project ID is used in commands and in configurations.
+
+1.  **Enable billing for your project**.
+    If you haven't already enabled billing for your project, [enable billing now](https://console.cloud.google.com/project/_/settings).
+    Enabling billing allows the application to consume billable resources such
+    as Speech API calls.  See [Google Cloud Console Help](https://support.google.com/cloud/answer/6288653) for more information about billing settings.
+
+1.  **Enable the Cloud Bigtable Admin APIs for your project**.
+    [Click here](https://console.cloud.google.com/flows/enableapi?apiid=bigtableadmin&showconfirmation=true) to visit Google Cloud Console and enable the Bigtable Admin API.
+
+1.  **Enable the Cloud Bigtable APIs for your project**.
+    [Click here](https://console.cloud.google.com/flows/enableapi?apiid=bigtable&showconfirmation=true) to visit Google Cloud Console and enable the Bigtable Admin API.
+
+1.  **Download service account credentials**.
+    These samples use service accounts for authentication.
+    1.  Visit the [Cloud Console](http://cloud.google.com/console), and navigate to:
+    `API Manager > Credentials > Create credentials > Service account key`
+    1.  Under **Service account**, select `New service account`.
+    1.  Under **Service account name**, enter a service account name of your choosing.  For example, `transcriber`.
+    1.  Under **Role**, select `Project > Service Account Actor`.
+    1.  Under **Key type**, leave `JSON` selected.
+    1.  Click **Create** to create a new service account, and download the json credentials file.
+    1.  Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to your downloaded service account credentials:
+        ```
+        export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/credentials-key.json
+        ```
+    See the [Cloud Platform Auth Guide](https://cloud.google.com/docs/authentication#developer_workflow) for more information.
+
+1.  **Install gRPC.**
+    1.  Visit [the gRPC github repo](https://github.com/grpc/grpc) and follow the instructions to install gRPC.
+    1.  Then, follow the instructions in the **Pre-requisites** section to install **protoc**.

--- a/bigtable/api/README.md
+++ b/bigtable/api/README.md
@@ -19,7 +19,8 @@ These samples demonstrate how to call the [Google Cloud Bigtable API](https://cl
 1.  **Enable billing for your project**.
     If you haven't already enabled billing for your project, [enable billing now](https://console.cloud.google.com/project/_/settings).
     Enabling billing allows the application to consume billable resources such
-    as Speech API calls.  See [Google Cloud Console Help](https://support.google.com/cloud/answer/6288653) for more information about billing settings.
+    as Cloud Bigtable API calls.
+    See [Google Cloud Console Help](https://support.google.com/cloud/answer/6288653) for more information about billing settings.
 
 1.  **Enable the Cloud Bigtable Admin APIs for your project**.
     [Click here](https://console.cloud.google.com/flows/enableapi?apiid=bigtableadmin&showconfirmation=true) to visit Google Cloud Console and enable the Bigtable Admin API.
@@ -29,7 +30,7 @@ These samples demonstrate how to call the [Google Cloud Bigtable API](https://cl
 
 1.  **Download service account credentials**.
     These samples use service accounts for authentication.
-    1.  Visit the [Cloud Console](http://cloud.google.com/console), and navigate to:
+    1.  Visit the [Google Cloud Console](http://cloud.google.com/console), and navigate to:
     `API Manager > Credentials > Create credentials > Service account key`
     1.  Under **Service account**, select `New service account`.
     1.  Under **Service account name**, enter a service account name of your choosing.  For example, `transcriber`.
@@ -67,5 +68,12 @@ These samples demonstrate how to call the [Google Cloud Bigtable API](https://cl
 
 1.  **Run the examples**
     ```console
+    # for example: list_instance my-project 
     ./list_instances <project_id>
+
+    # for example: create_instance my-project bt-test-instance cluster00 us-east1-c
+    ./create_instance <project_id> <instance_id> <cluster_id> <zone>
+
+    ./list_instances <project_id>
+    ./delete_instance <project_id> <instance_id>
     ```

--- a/bigtable/api/ci/build-linux.sh
+++ b/bigtable/api/ci/build-linux.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+if [ "x${DOCKER_BUILD}" != "xyes" ]; then
+  echo "Not a Docker-based build, exit successfully."
+  exit 0
+fi
+
+IMAGE="cached-${DISTRO?}-${DISTRO_VERSION?}"
+latest_id=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest >/dev/null || echo "")
+
+echo IMAGE = $IMAGE
+echo IMAGE LATEST ID = $latest_id
+
+# TODO() - on cron buiids, we would want to disable the cache
+# altogether, to make sure we can still build against recent versions
+# of grpc, protobug, the compilers, etc.
+cacheargs=""
+if [ "x${latest_id}" != "x" ]; then
+  cacheargs="--cache-from ${IMAGE?}:latest"
+fi
+
+echo cache args = $cacheargs
+
+sudo docker build -t ${IMAGE?}:tip ${cacheargs?} \
+     --build-arg DISTRO_VERSION=${DISTRO_VERSION?} \
+     --build-arg CXX=${CXX?} \
+     --build-arg CC=${CC?} \
+     --build-arg TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER} \
+     -f bigtable/api/docker/Dockerfile.${DISTRO?} bigtable/
+
+exit 0

--- a/bigtable/api/ci/build-macosx.sh
+++ b/bigtable/api/ci/build-macosx.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+if [ "x${MACOSX_BUILD}" != "xyes" ]; then
+  echo "Not a Mac OS X build, exit successfully"
+  exit 0
+fi
+
+cd bigtable/api
+make -C googleapis OUTPUT=$PWD/googleapis-gens
+
+# On my local workstation I prefer to keep all the build artifacts in
+# a sub-directory, not so important for Travis builds, but that makes
+# this script easier to test.
+test -d build || mkdir build
+
+cd build
+cmake ..
+
+make -j 2
+
+exit 0
+

--- a/bigtable/api/ci/cache-linux.sh
+++ b/bigtable/api/ci/cache-linux.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+if [ "x${DOCKER_BUILD}" != "xyes" ]; then
+  echo "Not a Docker-based build, exit successfully."
+  exit 0
+fi
+
+IMAGE=cached-${DISTRO?}-${DISTRO_VERSION?}
+TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz
+
+# The build creates a new "*:tip" image, we want to save it as
+# "*:latest" so it can be used as a cache source in the next build.
+sudo docker image tag ${IMAGE?}:tip ${IMAGE?}:latest
+
+sudo docker save ${IMAGE?}:latest | gzip - > ${TARBALL?}
+
+exit 0

--- a/bigtable/api/ci/install-linux.sh
+++ b/bigtable/api/ci/install-linux.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+if [ "x${DOCKER_BUILD}" != "xyes" ]; then
+  echo "Not a Docker-based build, exit successfully."
+  exit 0
+fi
+
+sudo apt-get update
+sudo apt-get install -y docker-ce
+sudo docker --version
+
+TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz
+if [ -f ${TARBALL?} ]; then
+  gunzip <${TARBALL?} | sudo docker load || echo "Could not load saved image, continue without cache"
+fi
+
+echo "DEBUG output for install script"
+ls -l docker-images/${DISTRO}/${DISTRO_VERSION} || /bin/true
+sudo docker image ls
+
+exit 0

--- a/bigtable/api/ci/install-macosx.sh
+++ b/bigtable/api/ci/install-macosx.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+if [ "x${MACOSX_BUILD}" != "xyes" ]; then
+  echo "Not a Mac OS X build, exit successfully."
+  exit 0
+fi
+
+brew install grpc protobuf
+
+echo "DEBUG output for install script"
+brew info grpc | grep '^/usr/local/Cellar' | awk '{print $1}'
+brew info protobuf | grep '^/usr/local/Cellar' | awk '{print $1}'
+
+pkg-config --cflags protobuf
+pkg-config --cflags grpc
+
+exit 0

--- a/bigtable/api/create_instance.cc
+++ b/bigtable/api/create_instance.cc
@@ -1,0 +1,159 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
+#include <google/longrunning/operations.grpc.pb.h>
+#include <google/protobuf/text_format.h>
+#include <grpc++/grpc++.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+int main(int argc, char* argv[]) try {
+  auto creds = grpc::GoogleDefaultCredentials();
+  // Notice that Bigtable has separate endpoints for different APIs,
+  // we are going to query the create an instance, which is one of the
+  // admin APIs, so connect to the bigtableadmin endpoint ...
+  auto channel = grpc::CreateChannel("bigtableadmin.googleapis.com", creds);
+
+  // ... save ourselves some typing ...
+  namespace admin = ::google::bigtable::admin::v2;
+  using admin::BigtableInstanceAdmin;
+
+  // ... a more interesting application would use getopt(3),
+  // getopt_long(3), or Boost.Options to parse the command-line, we
+  // want to keep things simple in the example ...
+  if (argc != 5) {
+    std::cerr << "Usage: create_instance <project_id> <instance_id> "
+              << "<cluster_id> <zone>" << std::endl;
+    return 1;
+  }
+  char const* project_id = argv[1];
+  char const* instance_id = argv[2];
+  char const* cluster_id = argv[3];
+  char const* zone = argv[4];
+
+  admin::CreateInstanceRequest req;
+  req.set_parent(std::string("projects/") + project_id);
+  req.set_instance_id(instance_id);
+
+  // ... in this demo we only create DEVELOPMENT instances ...
+  auto& instance = *req.mutable_instance();
+  instance.set_display_name(instance_id);
+  instance.set_type(admin::Instance::DEVELOPMENT);
+
+  auto& cluster = (*req.mutable_clusters())[cluster_id];
+  cluster.set_location(std::string("projects/") + project_id + "/locations/" +
+                       zone);
+
+  std::unique_ptr<BigtableInstanceAdmin::Stub> instance_admin(
+      BigtableInstanceAdmin::NewStub(channel));
+  std::unique_ptr<google::longrunning::Operations::Stub> operations(
+      google::longrunning::Operations::NewStub(channel));
+
+  // ... make the request to create an instance, that returns a "long
+  // running operation" object ...
+  grpc::ClientContext create_context;
+  google::longrunning::Operation operation;
+  auto status =
+      instance_admin->CreateInstance(&create_context, req, &operation);
+  if (not status.ok()) {
+    std::cerr << "Error in CreateInstance() request: " << status.error_message()
+              << " [" << status.error_code() << "] " << status.error_details()
+              << std::endl;
+    return 1;
+  }
+
+  // ... we poll the long running operation object at most 100 times,
+  // using some exponential backoff to be nice ...
+  using namespace ::std::chrono_literals;
+  auto const initial_wait = 100ms;  // probably too fast
+  auto const maximum_wait = 3min;
+  auto const maximum_iterations = 100;
+
+  auto wait = initial_wait;
+  bool done = operation.done();
+  for (int i = 0; i != maximum_iterations and not done; ++i) {
+    // ... wait a little bit before trying again ...
+    std::this_thread::sleep_for(wait);
+    // ... check the status of the operation ...
+    google::longrunning::GetOperationRequest opreq;
+    opreq.set_name(operation.name());
+    grpc::ClientContext ctx;
+    google::longrunning::Operation response;
+
+    auto status = operations->GetOperation(&ctx, opreq, &response);
+    if (not status.ok()) {
+      std::cerr << "Error in GetOperation() request, will try again: "
+                << status.error_message() << " [" << status.error_code() << "] "
+                << status.error_details() << std::endl;
+    } else if (response.done()) {
+      done = true;
+      operation.Swap(&response);
+      break;
+    }
+
+    wait = wait * 2;
+    if (wait > maximum_wait) {
+      wait = maximum_wait;
+    }
+  }
+  // ... the operation did not complete ...
+  if (not operation.done()) {
+    std::cerr << "Timeout waiting for CreateInstance() operation: "
+              << operation.name() << std::endl;
+    return 1;
+  }
+  // ... at this point the answer is in the 'reponse' variable ...
+  if (operation.has_error()) {
+    // ... the creation failed (but not immediately), report the error
+    // ...
+    auto const& error = operation.error();
+    std::string details;
+    (void)google::protobuf::TextFormat::PrintToString(error, &details);
+    std::cerr << "Error reported in CreateInstance() operation: "
+              << operation.name() << " - " << error.message() << " ["
+              << error.code() << "] " << details << std::endl;
+    return 1;
+  }
+  if (not operation.has_response()) {
+    std::cerr << "Missing response() field in successful CreateInstance() long "
+              << "running operation:" << operation.name() << std::endl;
+    return 1;
+  }
+
+  admin::Instance result;
+  if (not operation.response().UnpackTo(&result)) {
+    std::string text;
+    (void)google::protobuf::TextFormat::PrintToString(operation, &text);
+    std::cerr << "CreateInstance() operation was successful but returned"
+              << " an unexpected response=" << text << std::endl;
+    return 1;
+  }
+
+  std::string text;
+  (void)google::protobuf::TextFormat::PrintToString(result, &text);
+  std::cout << "CreateInstance() operation (" << operation.name()
+            << ") is successful with result=" << text << std::endl;
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+} catch (...) {
+  std::cerr << "Unknown exception raised" << std::endl;
+  return 1;
+}

--- a/bigtable/api/docker/Dockerfile.fedora
+++ b/bigtable/api/docker/Dockerfile.fedora
@@ -51,7 +51,8 @@ RUN (git clone https://github.com/grpc/grpc.git && \
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 # ... capture the arguments that control the build ...
-ARG CXX_COMPILER=clang++
+ARG CXX=clang++
+ARG CC=clang
 
 # ... capture the Travis job number, effectively this busts the cache
 # in each build, which we want anyway ...
@@ -62,9 +63,6 @@ RUN echo Running build=${TRAVIS_JOB_NUMBER}
 WORKDIR /var/tmp/build-samples
 COPY api /var/tmp/build-samples
 
-# ... in the travis builds, this checks out the same commit that
-# Travis is trying to build, when testing it just checksout the default
-# branch
-
-RUN (make -C googleapis OUTPUT=$PWD/googleapis-gens && \
-     cmake -DCMAKE_CXX_COMPILER=${CXX_COMPILER} . && make -j 2)
+# ... use separate RUN commands to speed up debugging in local workstations ...
+RUN make -C googleapis OUTPUT=$PWD/googleapis-gens
+RUN cmake -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} . && make -j 2

--- a/bigtable/api/docker/Dockerfile.fedora
+++ b/bigtable/api/docker/Dockerfile.fedora
@@ -1,0 +1,70 @@
+# Copyright 2017, Google Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Create a docker image with the C++ Google API examples built into it.
+# This Dockerfile requires docker 17.05 or higher, it uses an argument to set
+# the base image version, which was not supported in early versions of docker.
+ARG DISTRO_VERSION=24
+FROM fedora:$DISTRO_VERSION
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Install the pre-requisites, the long command line is to create as few
+# layers as possible in the image ...
+RUN dnf makecache && \
+  dnf install -y \
+    autoconf \
+    autoconf-archive \
+    automake \
+    clang \
+    cmake \
+    curl \
+    gcc-c++ \
+    git \
+    libtool \
+    make \
+    pkgconfig \
+    shtool \
+    wget && \
+  dnf clean all
+
+WORKDIR /var/tmp/build-grpc
+RUN (git clone https://github.com/grpc/grpc.git && \
+    cd grpc && git pull && git submodule update --init && \
+    make -j 2 LDXX="g++ -std=c++11" LD=gcc CXX="g++ -std=c++11" CC=gcc && \
+    make install && \
+    cd third_party/protobuf && make install && \
+    echo /usr/local/lib >/etc/ld.so.conf.d/local.conf && ldconfig)
+
+# ... by default, Fedora does not look for packages in
+# /usr/local/lib/pkgconfig ...
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+# ... capture the arguments that control the build ...
+ARG CXX_COMPILER=clang++
+
+# ... capture the Travis job number, effectively this busts the cache
+# in each build, which we want anyway ...
+ARG TRAVIS_JOB_NUMBER=
+RUN echo Running build=${TRAVIS_JOB_NUMBER}
+
+# ... copy the contents of the source code directory to the container ...
+WORKDIR /var/tmp/build-samples
+COPY api /var/tmp/build-samples
+
+# ... in the travis builds, this checks out the same commit that
+# Travis is trying to build, when testing it just checksout the default
+# branch
+
+RUN (make -C googleapis OUTPUT=$PWD/googleapis-gens && \
+     cmake -DCMAKE_CXX_COMPILER=${CXX_COMPILER} . && make -j 2)

--- a/bigtable/api/docker/Dockerfile.ubuntu
+++ b/bigtable/api/docker/Dockerfile.ubuntu
@@ -47,7 +47,8 @@ RUN (git clone https://github.com/grpc/grpc.git && \
     cd third_party/protobuf && make install)
 
 # ... capture the arguments that control the build ...
-ARG CXX_COMPILER=clang++
+ARG CXX=clang++
+ARG CC=clang
 
 # ... capture the Travis job number, effectively this busts the cache
 # in each build, which we want anyway ...
@@ -58,9 +59,6 @@ RUN echo Running build=${TRAVIS_JOB_NUMBER}
 WORKDIR /var/tmp/build-samples
 COPY api /var/tmp/build-samples
 
-# ... in the travis builds, this checks out the same commit that
-# Travis is trying to build, when testing it just checksout the default
-# branch
-
-RUN (make -C googleapis OUTPUT=$PWD/googleapis-gens && \
-     cmake -DCMAKE_CXX_COMPILER=${CXX_COMPILER} . && make -j 2)
+# ... use separate RUN commands to speed up debugging in local workstations ...
+RUN make -C googleapis OUTPUT=$PWD/googleapis-gens
+RUN cmake -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} . && make -j 2

--- a/bigtable/api/docker/Dockerfile.ubuntu
+++ b/bigtable/api/docker/Dockerfile.ubuntu
@@ -1,0 +1,66 @@
+# Copyright 2017, Google Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Create a docker image with the C++ Google API examples built into it.
+# This Dockerfile requires docker 17.05 or higher, it uses an argument to set
+# the base image version, which was not supported in early versions of docker.
+ARG DISTRO_VERSION=16.04
+FROM ubuntu:$DISTRO_VERSION
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Install the pre-requisites, the long command line is to create as few
+# layers as possible in the image ...
+RUN apt-get update && \
+  apt-get install --no-install-recommends --no-install-suggests -y \
+    autoconf \
+    autoconf-archive \
+    automake \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    g++ \
+    gcc \
+    git-core \
+    libtool \
+    lsb-release \
+    make \
+    pkg-config && \
+  apt-get clean
+
+WORKDIR /var/tmp/build-grpc
+RUN (git clone https://github.com/grpc/grpc.git && \
+    cd grpc && git pull && git submodule update --init && \
+    make -j 2 && make install && \
+    cd third_party/protobuf && make install)
+
+# ... capture the arguments that control the build ...
+ARG CXX_COMPILER=clang++
+
+# ... capture the Travis job number, effectively this busts the cache
+# in each build, which we want anyway ...
+ARG TRAVIS_JOB_NUMBER=
+RUN echo Running build=${TRAVIS_JOB_NUMBER}
+
+# ... copy the contents of the source code directory to the container ...
+WORKDIR /var/tmp/build-samples
+COPY api /var/tmp/build-samples
+
+# ... in the travis builds, this checks out the same commit that
+# Travis is trying to build, when testing it just checksout the default
+# branch
+
+RUN (make -C googleapis OUTPUT=$PWD/googleapis-gens && \
+     cmake -DCMAKE_CXX_COMPILER=${CXX_COMPILER} . && make -j 2)

--- a/bigtable/api/list_instances.cc
+++ b/bigtable/api/list_instances.cc
@@ -1,0 +1,83 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grpc++/grpc++.h>
+#include <iostream>
+#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
+
+int main(int argc, char* argv[]) try {
+  auto creds = grpc::GoogleDefaultCredentials();
+  // Notice that Bigtable has separate endpoints for different APIs,
+  // we are going to query the list of instances, which is one of the
+  // admin APIs, so connect to the bigtableadmin endpoint ...
+  auto channel = grpc::CreateChannel("bigtableadmin.googleapis.com", creds);
+
+  // ... save ourselves some typing ...
+  namespace admin = ::google::bigtable::admin::v2;
+  using admin::BigtableInstanceAdmin;
+
+  // ... a more interesting application would use getopt(3),
+  // getopt_long(3), or Boost.Options to parse the command-line, we
+  // want to keep things simple in the example ...
+  if (argc != 2) {
+    std::cerr << "Usage: list_instances <project_id>" << std::endl;
+    return 1;
+  }
+  char const* project_id = argv[1];
+
+  std::unique_ptr<BigtableInstanceAdmin::Stub> instance_admin(
+      BigtableInstanceAdmin::NewStub(channel));
+  admin::ListInstancesRequest req;
+  req.set_parent(std::string("projects/") + project_id);
+
+  // ... the API may return the list in "pages", it is rare that a
+  // project has so many instances that it requires multiple pages,
+  // but for completeness sake we document how to do it ...
+  int count = 0;
+  do {
+    grpc::ClientContext context;
+    admin::ListInstancesResponse response;
+    auto status = instance_admin->ListInstances(&context, req, &response);
+    if (not status.ok()) {
+      std::cerr << "Error in first ListInstances() request: "
+                << status.error_message() << " [" << status.error_code() << "] "
+                << status.error_details() << std::endl;
+      return 1;
+    }
+    for (auto const& instance : response.instances()) {
+      std::cout << "Instance[" << count << "]: " << instance.name() << ", "
+                << instance.display_name() << ", "
+                << admin::Instance_State_Name(instance.state()) << ", "
+                << admin::Instance_Type_Name(instance.type()) << "\n";
+      ++count;
+    }
+    for (auto const& location : response.failed_locations()) {
+      std::cout << "Failed location: " << location << "\n";
+    }
+    // ... nothing more to display, break the loop ...
+    if (response.next_page_token().empty()) {
+      break;
+    }
+    // ... request the next page ...
+    req.set_page_token(response.next_page_token());
+  } while (true);
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+} catch (...) {
+  std::cerr << "Unknown exception raised" << std::endl;
+  return 1;
+}


### PR DESCRIPTION
Create a simple program to list the Cloud Bigtable instances in a project, as well as the supporting `cmake` files, Travis build scripts, Dockerfiles to test with different distributions and compilers, and supporting documentation.

