### PR TITLE
Create an example of ReadRows()

### DIFF
--- a/bigtable/api/CMakeLists.txt
+++ b/bigtable/api/CMakeLists.txt
@@ -126,8 +126,11 @@ target_link_libraries(list_tables googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIE
 
 PROTOBUF_GENERATE_CPP(TAQ_PROTO_SRCS TAQ_PROTO_HDRS ${PROJECT_SOURCE_DIR}/taq.proto)
 
-add_executable(upload_taq upload_taq.cc ${TAQ_PROTO_SRCS} ${TAQ_PROTO_HDRS})
+add_executable(upload_taq upload_taq.cc parse_taq_line.cc ${TAQ_PROTO_SRCS} ${TAQ_PROTO_HDRS})
 target_link_libraries(upload_taq googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
-add_executable(upload_taq_batch upload_taq_batch.cc ${TAQ_PROTO_SRCS} ${TAQ_PROTO_HDRS})
+add_executable(upload_taq_batch upload_taq_batch.cc parse_taq_line.cc ${TAQ_PROTO_SRCS} ${TAQ_PROTO_HDRS})
 target_link_libraries(upload_taq_batch googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+add_executable(read_rows read_rows.cc ${TAQ_PROTO_SRCS} ${TAQ_PROTO_HDRS})
+target_link_libraries(read_rows googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})

--- a/bigtable/api/README.md
+++ b/bigtable/api/README.md
@@ -88,6 +88,17 @@ These samples demonstrate how to call the [Google Cloud Bigtable API](https://cl
 
     ./delete_table $PROJECT bt-test-instance my-table
 
+    ./create_table $PROJECT bt-test-instance daily
+    ./create_table $PROJECT bt-test-instance quote-per-row
+
+    ./resources/download_taq.sh
+
+    ./upload_taq $PROJECT bt-test-instance quote-per-row NBBO.txt
+
+    ./upload_taq_batch $PROJECT bt-test-instance quote-per-row 20161024 NBBO.txt
+
+    ./read_row $PROJECT bt-test-instance quote-per-row 20161024
+
     ./delete_instance $PROJECT bt-test-instance
 
     ./list_instances $PROJECT

--- a/bigtable/api/parse_taq_line.cc
+++ b/bigtable/api/parse_taq_line.cc
@@ -1,11 +1,24 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "parse_taq_line.h"
 
 #include <chrono>
 #include <sstream>
 
 namespace bigtable_api_samples {
-Quote parse_taq_line(
-    int lineno, std::string const& line) try {
+Quote parse_taq_line(int lineno, std::string const& line) try {
   // Return the parsed line in this object ...
   Quote quote;
 

--- a/bigtable/api/parse_taq_line.cc
+++ b/bigtable/api/parse_taq_line.cc
@@ -1,0 +1,65 @@
+#include "parse_taq_line.h"
+
+#include <chrono>
+#include <sstream>
+
+namespace bigtable_api_samples {
+Quote parse_taq_line(
+    int lineno, std::string const& line) try {
+  // Return the parsed line in this object ...
+  Quote quote;
+
+  // The data is in pipe separated fields, we extract them one at a time ...
+  std::istringstream tokens(line);
+  tokens.exceptions(std::ios::failbit);
+
+  // Time: in HHMMSSNNNNNNNNN format (hours, minutes, seconds, nanoseconds).
+  std::string tk;
+  std::getline(tokens, tk, '|');  // fetch the timestamp as a string
+
+  // ... parse the timestamp into a 64-bit long ...
+  if (tk.length() != 15U) {
+    std::ostringstream os;
+    os << "timestamp field (" << tk << ") is not in HHMMSSNNNNNNNNN format";
+    throw std::runtime_error(os.str());
+  }
+  int hh = std::stod(tk.substr(0, 2));
+  int mm = std::stod(tk.substr(2, 2));
+  int ss = std::stod(tk.substr(4, 2));
+  long long nnn = std::stoll(tk.substr(6));
+
+  using namespace std::chrono;
+  std::chrono::nanoseconds ns = duration_cast<nanoseconds>(hours(hh) + minutes(mm) +
+							   seconds(ss) + nanoseconds(nnn));
+
+  // ... store the number of nanoseconds in the timestamp ...
+  quote.set_timestamp_ns(ns.count());
+
+  // Exchange (ignored): a single character
+  std::getline(tokens, tk, '|');  // ignore the exchange
+
+  // Symbol: a string
+  std::getline(tokens, tk, '|');  // fetch the symbol
+  quote.set_ticker(std::move(tk));
+
+  // Bid_Price: float
+  std::getline(tokens, tk, '|');
+  quote.set_bid_px(std::stod(tk));
+  // Bid_Size: integer
+  std::getline(tokens, tk, '|');
+  quote.set_bid_qty(std::stol(tk));
+  // Offer_Price: float
+  std::getline(tokens, tk, '|');
+  quote.set_offer_px(std::stod(tk));
+  // Offer_Size: integer
+  std::getline(tokens, tk, '|');
+  quote.set_offer_qty(std::stol(tk));
+  // ... the TAQ line has many other fields that we ignore in this demo ...
+
+  return quote;
+} catch (std::exception const& ex) {
+  std::ostringstream os;
+  os << ex.what() << " in line #" << lineno << " (" << line << ")";
+  throw std::runtime_error(os.str());
+}
+} // namespace bigtable_api_samples

--- a/bigtable/api/parse_taq_line.h
+++ b/bigtable/api/parse_taq_line.h
@@ -1,0 +1,13 @@
+#ifndef parse_taq_line_h
+#define parse_taq_line_h
+
+#include "taq.pb.h"
+
+#include <utility>
+
+namespace bigtable_api_samples {
+// Parse a line from a TAQ file and convert it to a quote.
+Quote parse_taq_line(int lineno, std::string const& line);
+} // namespace bigtable_api_samples
+
+#endif // parse_taq_line_h

--- a/bigtable/api/parse_taq_line.h
+++ b/bigtable/api/parse_taq_line.h
@@ -21,6 +21,20 @@
 
 namespace bigtable_api_samples {
 // Parse a line from a TAQ file and convert it to a quote.
+//
+// TAQ files are delimiter (using '|' as the delimiter) separated text
+// files, using this format:
+//
+// timestamp|exchange|ticker|bid price|bid qty|offer price|offer qty|...
+// 093000123456789|K|GOOG|800.00|100|900.00|200|...
+// ...
+// END|20161024|78721395|||||||||||||||||||||||||
+//
+// The first line is a header, it defines the fields, each line
+// contains all the data for a quote, in this example we are only
+// interested in the first few fields, the last line is indicated by
+// the 'END' marker, it contains the date (timestamps are relative to
+// midnight on this date), and the total number of lines.
 Quote parse_taq_line(int lineno, std::string const& line);
 } // namespace bigtable_api_samples
 

--- a/bigtable/api/parse_taq_line.h
+++ b/bigtable/api/parse_taq_line.h
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef parse_taq_line_h
 #define parse_taq_line_h
 

--- a/bigtable/api/read_rows.cc
+++ b/bigtable/api/read_rows.cc
@@ -1,0 +1,164 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "taq.pb.h"
+
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+#include <google/rpc/status.pb.h>
+#include <grpc++/grpc++.h>
+
+#include <algorithm>
+#include <ciso646>
+#include <deque>
+#include <fstream>
+#include <sstream>
+#include <thread>
+
+// We want to show the correct way to receive a Bigtable cell value in
+// ReadRows().  Bigtable can break down cell values across multiple
+// messages, which requires reassembly of the result.  We assume a
+// table has been populated using the upload_taq_batch example, query
+// a few of the rows and calculate an (un)interesting value derived
+// from that data.
+int main(int argc, char* argv[]) try {
+  // ... a more interesting application would use getopt(3),
+  // getopt_long(3), or Boost.Options to parse the command-line, we
+  // want to keep things simple in the example ...
+  if (argc != 5) {
+    std::cerr
+        << "Usage: create_table <project_id> <instance_id> <table_id> <date>"
+        << std::endl;
+    return 1;
+  }
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_id = argv[3];
+  std::string const yyyymmdd = argv[4];
+
+  // ... save ourselves some typing ...
+  namespace bigtable = ::google::bigtable::v2;
+
+  // ... use the default credentials, this works automatically if your
+  // GCE instance has the Bigtable APIs enabled.  You can also set
+  // GOOGLE_APPLICATION_CREDENTIALS to work outside GCE, more details
+  // at:
+  //  https://grpc.io/docs/guides/auth.html
+  auto creds = grpc::GoogleDefaultCredentials();
+
+  // ... create the table if needed ...
+  std::string table_name = "projects/" + project_id +
+                           "/instances/" + instance_id + "/tables/" + table_id;
+
+  // ... notice that Bigtable has separate endpoints for different APIs,
+  // we are going to upload some data, so the correct endpoint is:
+  auto channel = grpc::CreateChannel("bigtable.googleapis.com", creds);
+
+  std::unique_ptr<bigtable::Bigtable::Stub> bt_stub(
+      bigtable::Bigtable::NewStub(channel));
+
+  // ... once the table is created and the data uploaded we can make
+  // the query ...
+  bigtable::ReadRowsRequest request;
+  request.set_table_name(table_name);
+
+  // ... show how to use filters, there are probably several ways to do this ...
+  auto& chain = *request.mutable_filter()->mutable_chain();
+  // ... first only accept the "taq" column family ...
+  chain.add_filters()->set_family_name_regex_filter("taq");
+  // ... then only accept the "quotes" column ...
+  chain.add_filters()->set_column_qualifier_regex_filter("quotes");
+
+  // ... the magic values "A" and "AA" happen to be the first two
+  // symbols in the TAQ file used in these examples.  That provides
+  // enough complexity to make the example interesting, but not so
+  // much that it becomes overwhelming.  A future example will show
+  // how to read multiple families and cells ...
+  // TODO(coryan) update this comment when that example is written ...
+  request.mutable_rows()->add_row_keys(yyyymmdd + "/A");
+  request.mutable_rows()->add_row_keys(yyyymmdd + "/AA");
+
+  grpc::ClientContext context;
+  auto stream = bt_stub->ReadRows(&context, request);
+
+  std::string current_row_key;
+  std::string current_column_family;
+  std::string current_column;
+  std::string current_value;
+  // ... receive the streaming response ...
+  bigtable::ReadRowsResponse response;
+  while (stream->Read(&response)) {
+    for (auto& cell_chunk : *response.mutable_chunks()) {
+      if (not cell_chunk.row_key().empty()) {
+	current_row_key = cell_chunk.row_key();
+      }
+      if (cell_chunk.has_family_name()) {
+	current_column_family = cell_chunk.family_name().value();
+	if (current_column_family != "taq") {
+	  throw std::runtime_error("strange, only 'taq' family name expected in the query");
+	}
+      }
+      if (cell_chunk.has_qualifier()) {
+	current_column = cell_chunk.qualifier().value();
+	if (current_column != "quotes") {
+	  throw std::runtime_error("strange, only 'quotes' column expected in the query");
+	}
+      }
+      if (cell_chunk.timestamp_micros() != 0) {
+	throw std::runtime_error("strange, only the 0 timestamp expected in the query");
+      }
+      if (cell_chunk.value_size() > 0) {
+	current_value.reserve(cell_chunk.value_size());
+      }
+      current_value.append(cell_chunk.value());
+      if (cell_chunk.commit_row()) {
+	// ... process this cell, we want to convert the value into a Quotes proto ...
+	Quotes quotes;
+	if (not quotes.ParseFromString(current_value)) {
+	  std::cerr << current_row_key << ": ParseFromString() failed" << std::endl;
+	} else if (quotes.bid_px_size() != quotes.offer_px_size() or quotes.bid_px_size() == 0) {
+	  std::cerr << current_row_key << ": mismatched or zero sizes bid="
+		    << quotes.bid_px_size() << ", offer=" << quotes.offer_px_size()
+		    << std::endl;
+	} else {
+	  double bid_px_sum =
+	    std::accumulate(quotes.bid_px().begin(), quotes.bid_px().end(), 0);
+	  double offer_px_sum =
+	    std::accumulate(quotes.offer_px().begin(), quotes.offer_px().end(), 0);
+	  double average_spread =
+	    (offer_px_sum - bid_px_sum) / quotes.offer_px_size();
+	  std::cout << current_row_key << ": average spread="
+		    << average_spread << ", count=" << quotes.offer_px_size()
+		    << std::endl;
+	}
+      }
+      if (cell_chunk.reset_row()) {
+	current_value.clear();
+      }
+    }
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+} catch (...) {
+  std::cerr << "Unknown exception raised" << std::endl;
+  return 1;
+}
+
+namespace {
+}  // anonymous namespace

--- a/bigtable/api/taq.proto
+++ b/bigtable/api/taq.proto
@@ -14,8 +14,7 @@
 
 syntax = "proto3";
 
-// Specifies how a TAQ quote is stored in the Bigtable example
-message TAQ {
+message Quote {
   // The symbol or ticker for this quote
   string ticker = 1;
 
@@ -33,4 +32,25 @@ message TAQ {
 
   // The best offer quantiy
   int32 offer_qty = 6;
+}
+
+// Specifies how a sequence of TAQ quotes is stored in the Bigtable example
+message Quotes {
+  // The symbol or ticker for this quote
+  string ticker = 1;
+
+  // The timestamp, as nanoseconds since midnight
+  repeated int64 timestamp_ns = 2;
+
+  // The best bid price
+  repeated double bid_px = 3;
+
+  // The bid quantity
+  repeated int32 bid_qty = 4;
+
+  // The best offer price
+  repeated double offer_px = 5;
+
+  // The best offer quantiy
+  repeated int32 offer_qty = 6;
 }

--- a/bigtable/api/upload_taq_batch.cc
+++ b/bigtable/api/upload_taq_batch.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "taq.pb.h"
+#include "parse_taq_line.h"
 
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <google/rpc/status.pb.h>
@@ -30,9 +30,10 @@ namespace {
 // ... save ourselves some typing ...
 namespace bigtable = ::google::bigtable::v2;
 
-// Parse a line from the souce file ane turn it into a KV pair.
-std::pair<std::string, std::string> parse_taq_line(int lineno,
-                                                   std::string const& line);
+// Append a set of quotes to a mutate request
+void append_to_request(bigtable::MutateRowsRequest& request,
+                       std::string const& yyyymmdd,
+		       Quotes const& quotes);
 
 // Perform a Bigtable::MutateRows() request until all mutations complete.
 void mutate_with_retries(bigtable::Bigtable::Stub& bt_stub,
@@ -40,20 +41,38 @@ void mutate_with_retries(bigtable::Bigtable::Stub& bt_stub,
 
 }  // anonymous namespace
 
+// We want to show a more efficient way to update rows in Bigtable,
+// batching multiple updates into a single request.
+//
+// We use TAQ data for the source, this is a text file, with fields
+// separated by '|' characters (so really a CSV file with an uncommon
+// separator), with contents like this:
+//
+// timestamp|exchange|ticker|bid price|bid qty|offer price|offer qty|...
+// 093000123456789|K|GOOG|800.00|100|900.00|200|...
+// 093001123456789|K|GOOG|801.00|200|901.00|300|...
+//
+// Each row represents a market data quote, each file represents a
+// different day of trading, so the timestamps are expressed in
+// nanoseconds since midnight (in a strange format, but we digress).
+//
+// In this example we will collect all the quotes for a single symbol
+// and upload them to a single row and cell in a Bigtable.
 int main(int argc, char* argv[]) try {
   // ... a more interesting application would use getopt(3),
   // getopt_long(3), or Boost.Options to parse the command-line, we
   // want to keep things simple in the example ...
-  if (argc != 5) {
+  if (argc != 6) {
     std::cerr
-        << "Usage: create_table <project_id> <instance_id> <table> <filename>"
+        << "Usage: create_table <project_id> <instance_id> <table> <yyyymmdd> <filename>"
         << std::endl;
-    return 1;
+   return 1;
   }
-  char const* project_id = argv[1];
-  char const* instance_id = argv[2];
-  char const* table_id = argv[3];
-  char const* filename = argv[4];
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_id = argv[3];
+  std::string const yyyymmdd = argv[4];
+  std::string const filename = argv[5];
 
   auto creds = grpc::GoogleDefaultCredentials();
   // ... notice that Bigtable has separate endpoints for different APIs,
@@ -72,7 +91,9 @@ int main(int argc, char* argv[]) try {
   // something like Cloud Dataflow, where the upload work is sharded
   // across many clients, and should really take advantage of the
   // batch APIs ...
-  int const max_lines = 1000000;
+  int const max_lines_to_upload = 1000000;
+  // ... every few lines print out the progress because the author is
+  // impatient ...
   int const report_progress_rate = 20000;
   // ... we upload batch_size rows at a time, nothing magical about
   // 1024, just a nice round number picked by the author ...
@@ -80,23 +101,32 @@ int main(int argc, char* argv[]) try {
 
   std::ifstream is(filename);
   std::string line;
-  std::getline(is, line, '\n');  // ... skip the header ...
+  // ... skip the header line in the file ...
+  std::getline(is, line, '\n');
+
   bigtable::MutateRowsRequest request;
   request.set_table_name(table_name);
-  for (int lineno = 1; lineno != max_lines and not is.eof() and is; ++lineno) {
+  Quotes quotes;
+  int lineno = 1;
+  for (; lineno != max_lines_to_upload and not is.eof() and is; ++lineno) {
     std::getline(is, line, '\n');
-    auto kv = parse_taq_line(lineno, line);
-    // ... add one more entry to the batch request ...
-    auto& entry = *request.add_entries();
-    entry.set_row_key(std::move(kv.first));
-    auto& set_cell = *entry.add_mutations()->mutable_set_cell();
-    set_cell.set_family_name("taq");
-    set_cell.set_column_qualifier("message");
-    set_cell.set_value(std::move(kv.second));
-    // ... we use the timestamp field as a simple revision count in
-    // this example, so set it to 0.  The actual timestamp of the
-    // quote is stored in the key ...
-    set_cell.set_timestamp_micros(0);
+    auto q = bigtable_api_samples::parse_taq_line(lineno, line);
+    if (quotes.ticker() != q.ticker()) {
+      if (not quotes.ticker().empty()) {
+	append_to_request(request, yyyymmdd, quotes);
+      }
+      quotes.set_ticker(q.ticker());
+      quotes.clear_timestamp_ns();
+      quotes.clear_bid_px();
+      quotes.clear_bid_qty();
+      quotes.clear_offer_px();
+      quotes.clear_offer_qty();
+    }
+    quotes.add_timestamp_ns(q.timestamp_ns());
+    quotes.add_bid_px(q.bid_px());
+    quotes.add_bid_qty(q.bid_qty());
+    quotes.add_offer_px(q.offer_px());
+    quotes.add_offer_qty(q.offer_qty());
 
     if (request.entries_size() >= batch_size) {
       mutate_with_retries(*bt_stub, request);
@@ -106,8 +136,9 @@ int main(int argc, char* argv[]) try {
     }
   }
   // ... CS101: the last batch needs to be uploaded too ...
+  append_to_request(request, yyyymmdd, quotes);
   mutate_with_retries(*bt_stub, request);
-  std::cout << max_lines << " quotes successfully uploaded" << std::endl;
+  std::cout << lineno << " quotes successfully uploaded" << std::endl;
 
   return 0;
 } catch (std::exception const& ex) {
@@ -119,54 +150,26 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
-// TODO(coryan) - this should return a proto representing the TAQ data.
-std::pair<std::string, std::string> parse_taq_line(
-    int lineno, std::string const& line) try {
-  // The data is in pipe separated fields, starting with:
-  // Time: in HHMMSSNNNNNNNNN format (hours, minutes, seconds, nanoseconds).
-  // Exchange: a single character
-  // Symbol: a string
-  // Bid_Price: float
-  // Bid_Size: integer
-  // Offer_Price: float
-  // Offer_Size: integer
-  // ... and many other fields we ignore in this demo.
-  std::istringstream tokens(line);
-  tokens.exceptions(std::ios::failbit);
-  std::string tk;
-  std::getline(tokens, tk, '|');  // fetch the timestamp
-
-  // ... the key will be a combination of timestamp and symbol, to
-  // avoid hotspotting by either ...
-  std::string key = tk + "/";
-  std::getline(tokens, tk, '|');  // ignore the exchange
-  std::string symbol;
-  std::getline(tokens, symbol, '|');  // fetch the symbol
-  key += tk;
-
-  // ... the value is built using a proto
-  TAQ quote;
-  std::getline(tokens, tk, '|');
-  quote.set_bid_px(std::stod(tk));
-  std::getline(tokens, tk, '|');
-  quote.set_bid_qty(std::stol(tk));
-  std::getline(tokens, tk, '|');
-  quote.set_offer_px(std::stod(tk));
-  std::getline(tokens, tk, '|');
-  quote.set_offer_qty(std::stol(tk));
-
+void append_to_request(bigtable::MutateRowsRequest& request,
+                       std::string const& yyyymmdd,
+		       Quotes const& quotes) {
+  // ... add one more entry to the batch request ...
+  auto& entry = *request.add_entries();
+  entry.set_row_key(yyyymmdd + "/" + quotes.ticker());
+  auto& set_cell = *entry.add_mutations()->mutable_set_cell();
+  set_cell.set_family_name("taq");
+  set_cell.set_column_qualifier("quotes");
   std::string value;
-  if (not quote.SerializeToString(&value)) {
+  if (not quotes.SerializeToString(&value)) {
     std::ostringstream os;
-    os << "could not serialize quote at line #" << lineno << "(" << line << ")";
+    os << "could not serialize quotes for " << quotes.ticker();
     throw std::runtime_error(os.str());
   }
-
-  return std::make_pair(std::move(key), std::move(value));
-} catch (std::exception const& ex) {
-  std::ostringstream os;
-  os << ex.what() << " in line #" << lineno << " (" << line << ")";
-  throw std::runtime_error(os.str());
+  set_cell.mutable_value()->swap(value);
+  // ... we use the timestamp field as a simple revision count in
+  // this example, so set it to 0.  The actual timestamp of the
+  // quote is stored in the key ...
+  set_cell.set_timestamp_micros(0);
 }
 
 bool should_retry(int code) {


### PR DESCRIPTION
* Start on example for the ReadRow() api.

I refactored the code to parse TAQ files to a separate file and
also cleaned up the protos to represent TAQ quotes.

* Make read_row and upload_taq_batch work together.

* Rename to read_rows.

* Add missing #include for Linux.

* Fix errors on g++ builds.

* Address feedback from PR review.

* Use chain filters instead of condition filters.

* Simplify example of chunk processing.

Merge into a single value using value_size() instead of using
the io::ZeroCopy* protobuf streams.  The latter might be more
efficient, but they complicate the example.